### PR TITLE
fix: OrderDetailView 버튼 터치 시 Firestore User에 있는 데이터 업데이트

### DIFF
--- a/SininaCake/Scene/Login/LoginViewModel.swift
+++ b/SininaCake/Scene/Login/LoginViewModel.swift
@@ -255,9 +255,11 @@ extension LoginViewModel {
         let userName = user.displayName ?? ""
         
         // TODO: - 함수로 축약
-        self.loginUserEmail = email
-        self.imgURL = imgURL
-        self.userName = userName
+        DispatchQueue.main.async {
+            self.loginUserEmail = email
+            self.imgURL = imgURL
+            self.userName = userName
+        }
         
         self.storeUserInfo(email: email,
                            imgURL: imgURL,

--- a/SininaCake/Scene/Manager/OrderDetail/OrderDetailView.swift
+++ b/SininaCake/Scene/Manager/OrderDetail/OrderDetailView.swift
@@ -397,8 +397,8 @@ struct BottomButton: View {
     @Binding var orderItem: OrderItem
     @Binding var toggle: Bool
     @Binding var totalPrice: String
-    var account: String = "신한 110 544 626471"
     @ObservedObject var fcmAPI: FCMServerAPI
+    let account: String = "신한 110 544 626471"
     
     var buttonStyle: (String, UIColor) {
         switch orderItem.status {
@@ -447,7 +447,6 @@ struct BottomButton: View {
                 orderDetailVM.updateStatus(orderItem: orderItem)
             // TODO: - 완료 로직 추가
             case .complete: break
-                    
             }
             
             presentationMode.wrappedValue.dismiss()

--- a/SininaCake/Scene/Manager/OrderDetail/OrderDetailViewModel.swift
+++ b/SininaCake/Scene/Manager/OrderDetail/OrderDetailViewModel.swift
@@ -17,17 +17,17 @@ class OrderDetailViewModel: ObservableObject {
     @Published var deviceToken: String = ""
     
     func updatePrice(orderItem: OrderItem, _ price: Int) {
-//        db.collection("Users").document(orderItem.email).collection("Orders").document(orderItem.id).updateData(["confirmedPrice":price])
+        db.collection("Users").document(orderItem.email).collection("Orders").document(orderItem.id).updateData(["confirmedPrice":price])
         db.collection("CurrentOrders").document(orderItem.id).updateData(["confirmedPrice":price])
     }
     
     func updateStatus(orderItem: OrderItem) {
         switch orderItem.status {
         case .notAssign:
-//            db.collection("Users").document(orderItem.email).collection("Orders").document(orderItem.id).updateData(["status":"승인"])
+            db.collection("Users").document(orderItem.email).collection("Orders").document(orderItem.id).updateData(["status":"승인"])
             db.collection("CurrentOrders").document(orderItem.id).updateData(["status":"승인"])
         case .assign:
-//            db.collection("Users").document(orderItem.email).collection("Orders").document(orderItem.id).updateData(["status":"완료"])
+            db.collection("Users").document(orderItem.email).collection("Orders").document(orderItem.id).updateData(["status":"완료"])
             db.collection("CurrentOrders").document(orderItem.id).updateData(["status":"완료"])
         default:
             return


### PR DESCRIPTION
- OrderDetailView 버튼 터치 시 FIreStore User에 있는 데이터가 업데이트 안되는 현상 수정
- LoginViewModel에서 getFirebaseUserInfo 메서드 실행 시 Published로 선언된 변수 메인 스레드에서 업데이트 되도록 수정